### PR TITLE
Update slow conditional test for Feb 2026

### DIFF
--- a/bug-repros/slow-conditional-breakpoints/UnitTest1.cs
+++ b/bug-repros/slow-conditional-breakpoints/UnitTest1.cs
@@ -31,7 +31,7 @@ public class Tests
             {
                 Console.WriteLine("Test");
             }
-            // On a i7-4770K @ 3.5GGHz Windows computer I get the following results for the time taken for these 3 scenarios:
+            // On a Windows PR with a i7-4770K @ 3.50GHz processor, I get the following results for the time taken for these 3 scenarios:
             // 1. < 0.1ms
             // 2. < 0.1ms
             // 3. ~3 minutes

--- a/bug-repros/slow-conditional-breakpoints/UnitTest1.cs
+++ b/bug-repros/slow-conditional-breakpoints/UnitTest1.cs
@@ -25,17 +25,16 @@ public class Tests
 
             // Try the following and in each case check the "Time taken to reach this point: " output:
             // 1. Run this test without any breakpoints.
-            // 2. Put a regular breakpoint on the "if (tmp == 99999)" line below 
-            // 3. Finally change the breakpoint for a conditional breakpoint on (i == 24601)
+            // 2. Put a regular breakpoint on the "Console.WriteLine" line below 
+            // 3. Finally put a conditional breakpoint of (i == 24601) on the 'if (i == 99999)' line below
             if (i == 99999)
             {
                 Console.WriteLine("Test");
             }
-            // On a PC with a i7-4770K @ 3.50GHz processor I get the following results for the time taken
-            // 1. ~ 0.1ms
-            // 2. ~1 s
+            // On a i7-4770K @ 3.5GGHz Windows computer I get the following results for the time taken for these 3 scenarios:
+            // 1. < 0.1ms
+            // 2. < 0.1ms
             // 3. ~3 minutes
-            // ie the result for 3 being ~2 orders of magnitude slower than 2, and 2 ~4 orders of magnitude slower than 1
         }
     }
 }

--- a/bug-repros/slow-conditional-breakpoints/UnitTest1.cs
+++ b/bug-repros/slow-conditional-breakpoints/UnitTest1.cs
@@ -31,7 +31,7 @@ public class Tests
             {
                 Console.WriteLine("Test");
             }
-            // On a Windows PR with a i7-4770K @ 3.50GHz processor, I get the following results for the time taken for these 3 scenarios:
+            // On a Windows PR with a i7-4770K @ 3.50GHz processor, I get the following results for the "Time taken to reach this point: " time for these 3 scenarios:
             // 1. < 0.1ms
             // 2. < 0.1ms
             // 3. ~3 minutes

--- a/bug-repros/slow-conditional-breakpoints/UnitTest1.cs
+++ b/bug-repros/slow-conditional-breakpoints/UnitTest1.cs
@@ -31,10 +31,11 @@ public class Tests
             {
                 Console.WriteLine("Test");
             }
-            // On a Windows PR with a i7-4770K @ 3.50GHz processor, I get the following results for the "Time taken to reach this point: " time for these 3 scenarios:
+            // I get the following results for the "Time taken to reach this point: " time for these 3 scenarios:
             // 1. < 0.1ms
             // 2. < 0.1ms
             // 3. ~3 minutes
+            // This is on a Windows PC with a i7-4770K @ 3.50GHz processor, with .NET10 installed and using Jetbrains Rider 2025.3.3
         }
     }
 }

--- a/bug-repros/slow-conditional-breakpoints/slow-conditional-breakpoints.csproj
+++ b/bug-repros/slow-conditional-breakpoints/slow-conditional-breakpoints.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>slow_conditional_breakpoints</RootNamespace>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
- NET10 from NET9
- clarified repro instructions
- ran using latest Rider at time of test (2025.3.3)